### PR TITLE
Add condition to check if request is null

### DIFF
--- a/src/java/fr/paris/lutece/plugins/stock/modules/recommendation/web/RecommendationApp.java
+++ b/src/java/fr/paris/lutece/plugins/stock/modules/recommendation/web/RecommendationApp.java
@@ -111,10 +111,13 @@ public class RecommendationApp extends MVCApplication
         // ////////// Test features - begin
         strUserName = AppPropertiesService.getProperty( PROPERTY_TEST_USER );
 
-        String strRequestUser = request.getParameter( PARAMETER_USERNAME );
-        if ( strRequestUser != null )
+        if ( request != null )
         {
-            strUserName = strRequestUser;
+            String strRequestUser = request.getParameter( PARAMETER_USERNAME );
+            if ( strRequestUser != null )
+            {
+                strUserName = strRequestUser;
+            }
         }
         // ////////// Test features - end
 


### PR DESCRIPTION
Request can be null.
For example we got plenty of NullPointerExceptions when used with fr.paris.lutece.portal.service.search.PageIndexer[#L223](https://github.com/lutece-platform/lutece-core/blob/dcb42f0ac5f9369104b5d72b6f175b81d0e94793/src/java/fr/paris/lutece/portal/service/search/PageIndexer.java#L223)